### PR TITLE
Fix crash when installing

### DIFF
--- a/data/gdebi.desktop.in
+++ b/data/gdebi.desktop.in
@@ -2,7 +2,7 @@
 _Name=GDebi Package Installer
 _GenericName=Package Installer
 _Comment=Install and view software packages
-Exec=gdebi-gtk %f
+Exec=sh -c "gdebi-gtk %f"
 Icon=package
 Terminal=false
 Type=Application


### PR DESCRIPTION
It has to install as root, and when not wrapping the Exec in sh -c it crashes when anything requires root access. This happens for example when you install a deb file in a browser.